### PR TITLE
Test against current and LTS node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,7 @@
 language: node_js
 node_js:
-  - "0.10"
-  - 0.12
-  - iojs
+  - "4"
+  - "6"
 
 before_install:
   - npm install -g grunt-cli


### PR DESCRIPTION
If you'd like to still test `0.10` and `0.12` I can add them back. I think it's better to promote usage of stable/maintained versions node.